### PR TITLE
Customize avoiding domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,37 +25,37 @@ the name. Otherwise, MynaBird builds the account name from the domain.
 
 For example:
 
-  brendan@wistia.com                  -> wistia
-  brendan.schwartz@gmail.com          -> brendan-schwartz
-  brendan+nospam@gmail.com            -> brendan
-  support@gmail.com                   -> support-at-gmail
+    brendan@wistia.com                  -> wistia
+    brendan.schwartz@gmail.com          -> brendan-schwartz
+    brendan+nospam@gmail.com            -> brendan
+    support@gmail.com                   -> support-at-gmail
 
 Ok, that last one is a bit of a special case, but you get the idea.
 
 
-Usage:
+## Usage
 
-  require 'myna_bird'
-  MynaBird.convert('brendan@wistia.com')  #=> 'wistia'
+    require 'myna_bird'
+    MynaBird.convert('brendan@wistia.com')  #=> 'wistia'
 
 You can also tell MynaBird to avoid a list of domains. No need to include the
 TLD, just a second-level domain. For example:
 
-  MynaBird.avoid_domains = ['coolmail', 'bestmail']
-  MynaBird.convert('best.business@coolmail.com')  #=> 'best-business'
+    MynaBird.avoid_domains = ['coolmail', 'bestmail']
+    MynaBird.convert('best.business@coolmail.com')  #=> 'best-business'
 
 
-Specs:
+## Specs
 
   Just run "rake spec" to run the specs.
   Don't be shy, feel free to add more examples.
 
 
-Questions:
+## Questions
 
   Feel free to email me at brendan@wistia.com with any questions.
 
 
-License:
+## License:
 
   Go nuts. See LICENSE for full details.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Usage:
   require 'myna_bird'
   MynaBird.convert('brendan@wistia.com')  #=> 'wistia'
 
+You can also tell MynaBird to avoid a list of domains. No need to include the
+TLD, just a second-level domain. For example:
+
+  MynaBird.avoid_domains = ['coolmail', 'bestmail']
+  MynaBird.convert('best.business@coolmail.com')  #=> 'best-business'
+
 
 Specs:
 

--- a/lib/myna_bird.rb
+++ b/lib/myna_bird.rb
@@ -24,6 +24,18 @@ class MynaBird
     new(email).name
   end
 
+  def self.reset_avoided_domains
+    @avoided_domains = nil
+  end
+
+  def self.avoided_domains=(keys)
+    @avoided_domains = keys
+  end
+
+  def self.avoided_domains
+    @avoided_domains || []
+  end
+
   def initialize(email)
     # email must be in a somewhat sane format
     # i.e. have an @ sign and at least one letter or number on each side of it
@@ -36,11 +48,11 @@ class MynaBird
 
   # extract the name
   def name
-    if common_local? && common_domain?
+    if common_local? && (common_domain? || avoided_domain?)
       local_name + '-at-' + domain_name
     elsif common_local?
       domain_name
-    elsif common_domain?
+    elsif (common_domain? || avoided_domain?)
       local_name
     else
       domain_name
@@ -63,6 +75,12 @@ class MynaBird
     name.gsub!(/\-$/,'')
     name.gsub!(/^\-/,'')
     name
+  end
+
+  def avoided_domain?
+    self.class.avoided_domains.any? do |domain|
+      /#{domain}/.match(@domain)
+    end
   end
 
   def common_domain?

--- a/lib/myna_bird.rb
+++ b/lib/myna_bird.rb
@@ -28,8 +28,8 @@ class MynaBird
     @avoided_domains = nil
   end
 
-  def self.avoided_domains=(keys)
-    @avoided_domains = keys
+  def self.avoided_domains=(domains)
+    @avoided_domains = domains
   end
 
   def self.avoided_domains

--- a/myna_bird.gemspec
+++ b/myna_bird.gemspec
@@ -6,7 +6,7 @@
 
 Gem::Specification.new do |s|
   s.name = "myna_bird"
-  s.version = "0.2.11"
+  s.version = "0.2.12"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib"]

--- a/spec/myna_bird_spec.rb
+++ b/spec/myna_bird_spec.rb
@@ -26,4 +26,10 @@ describe MynaBird do
   it_should_not_convert '@@@@'
   it_should_not_convert '++@++'
 
+  context 'domain should be avoided' do
+    it 'uses the local name' do
+      MynaBird.avoided_domains = ['post-jazz']
+      MynaBird.convert('davej@post-jazz.no').should == 'davej'
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ require 'rspec'
 
 module ShouldAndShouldNotConvert
   def it_should_convert(from, to_hash)
-    to = to_hash[:to]    
+    to = to_hash[:to]
     it "should convert '#{from}' to '#{to}'" do
       MynaBird.convert(from).should == to
     end
@@ -22,4 +22,7 @@ end
 
 RSpec.configure do |config|
   config.extend(ShouldAndShouldNotConvert)
+  config.after do
+    MynaBird.reset_avoided_domains
+  end
 end


### PR DESCRIPTION
This allows folks who use this library to customize which domains should not be returned from `MynaBird::convert`, effectively putting those domains on the same footing as `MynaBird::COMMON_DOMAINS`. MynaBird will use the name part of the email if the domain part includes any second-level domains passed to `MynaBird::avoid_domains=`. See the README and the specs examples.

