### PR TITLE
Fix issue where MynaBird treats avoided domains differently than comm…

### DIFF
--- a/lib/myna_bird.rb
+++ b/lib/myna_bird.rb
@@ -79,22 +79,14 @@ class MynaBird
 
   def avoided_domain?
     self.class.avoided_domains.any? do |domain|
-      /#{domain}/.match(@domain)
+      matches_domain?(domain)
     end
   end
 
   def common_domain?
-    COMMON_DOMAINS.each do |domain|
-      if domain.is_a?(Regexp)
-        return true if domain.match(@domain)
-      elsif domain =~ /\./
-        return true if /#{domain}$/.match(@domain)
-      else
-        return true if /^#{domain}\./.match(@domain)
-      end
+    COMMON_DOMAINS.any? do |domain|
+      matches_domain?(domain)
     end
-
-    return false
   end
 
   def common_local?
@@ -109,4 +101,17 @@ class MynaBird
     return false
   end
 
+  private
+
+  def matches_domain?(domain)
+    if domain.is_a?(Regexp)
+      return true if domain.match(@domain)
+    elsif domain =~ /\./
+      return true if /#{domain}$/.match(@domain)
+    else
+      return true if /^#{domain}\./.match(@domain)
+    end
+
+    false
+  end
 end

--- a/spec/myna_bird_spec.rb
+++ b/spec/myna_bird_spec.rb
@@ -1,7 +1,6 @@
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe MynaBird do
-
   it_should_convert 'brendan@wistia.com',              to: 'wistia'
   it_should_convert 'brendan.schwartz@gmail.com',      to: 'brendan-schwartz'
   it_should_convert 'support@gmail.com',               to: 'support-at-gmail'
@@ -18,6 +17,7 @@ describe MynaBird do
   it_should_convert 'BRENDAN@WISTIA',                  to: 'wistia'
   it_should_convert 'brendan@outlook.com',             to: 'brendan'
   it_should_convert 'james@outlook.com.br',            to: 'james'
+  it_should_convert 'james@karaol.com',                to: 'karaol'
 
   # bad input
   it_should_not_convert 'no.at.sign'
@@ -26,10 +26,12 @@ describe MynaBird do
   it_should_not_convert '@@@@'
   it_should_not_convert '++@++'
 
-  context 'domain should be avoided' do
-    it 'uses the local name' do
-      MynaBird.avoided_domains = ['post-jazz']
-      MynaBird.convert('davej@post-jazz.no').should == 'davej'
+  describe '.avoided_domains' do
+    before do
+      MynaBird.avoided_domains = ['post-jazz', 'my']
     end
+
+    it_should_convert 'davej@post-jazz.no',            to: 'davej'
+    it_should_convert 'thijs@mychickennuggets.com',    to: 'mychickennuggets'
   end
 end


### PR DESCRIPTION
This PR fixes an issue where avoided domains would only do a partial match of the avoided domain causing a lot of false positives. For example, adding "my" as an avoided domain would than consider "mychickennuggets" an avoided domain. We should make the behavior consistent between common and avoided domains.